### PR TITLE
Wrap tkinter launcher in main

### DIFF
--- a/video_player.py
+++ b/video_player.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import random
 import tkinter as tk
@@ -284,6 +285,11 @@ class VideoPlayerApp:
 
 
 # 创建并运行Tkinter主循环
-root = tk.Tk()
-app = VideoPlayerApp(root)
-root.mainloop()
+def main():
+    root = tk.Tk()
+    app = VideoPlayerApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add missing shebang for Python
- move Tk initialization and main loop into a `main()` function
- call `main()` when executed as a script

## Testing
- `python3 -m py_compile video_player.py`

------
https://chatgpt.com/codex/tasks/task_e_684c13fb3eb883319ef854c130198588